### PR TITLE
Add missing bounds check in flash attention's online softmax

### DIFF
--- a/src/attention.jl
+++ b/src/attention.jl
@@ -78,6 +78,7 @@
         # ---- online soft-max ---------------------------------------------
         m_ij = typemin(T)
         @unroll for i in 1:gsz
+            (in_seq_bounds || k_offset + i ≤ size(k, 2)) || break
             m_ij = max(m_ij, s_shm[tidx, i])
         end
 


### PR DESCRIPTION
I've been trying to understand flash attention better after seeing some NaNs when switching from Qwen3 to Qwen2.5. After narrowing it down to flash attention, I found that removing some occurrences of this line
```julia
(in_seq_bounds || k_offset + i ≤ size(k, 2)) || break
```
seemed to fix it, and then I realized that the real problem was that one instance of the line was missing in the online softmax.
Not sure why I only saw this with Qwen2.5-0.5B. The only real difference seems to be that Qwen2.5-0.5B has 14 heads instead of Qwen3-0.6B's 16.